### PR TITLE
Add count method for rows and corresponding tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,15 +326,14 @@ function OrcaScanNode(apiKey, options) {
          *
          * @param {string} sheetId - target sheet id
          * @returns {Promise<object>} promise resolving to result
-         *   {object} data - count result
-         *   {number} data.count - total number of rows
+         *   {number} count - total number of rows
          *
          * @example
          * // get total number of rows in a sheet
          * orca.rows.count('SHEET_ID')
          *     .then(function (result) {
-         *         // result.data.count contains the total number of rows
-         *         console.log('Total rows:', result.data.count);
+         *         // result.count contains the total number of rows
+         *         console.log('Total rows:', result.count);
          *     })
          *     .catch(function (err) {
          *         // handle error

--- a/index.js
+++ b/index.js
@@ -323,10 +323,23 @@ function OrcaScanNode(apiKey, options) {
 
         /**
          * get the total number of rows in a sheet
+         *
          * @param {string} sheetId - target sheet id
          * @returns {Promise<object>} promise resolving to result
          *   {object} data - count result
          *   {number} data.count - total number of rows
+         *
+         * @example
+         * // get total number of rows in a sheet
+         * orca.rows.count('SHEET_ID')
+         *     .then(function (result) {
+         *         // result.data.count contains the total number of rows
+         *         console.log('Total rows:', result.data.count);
+         *     })
+         *     .catch(function (err) {
+         *         // handle error
+         *         console.error(err);
+         *     });
          */
         count: function (sheetId) {
             if (!sheetId || typeof sheetId !== 'string') throw new Error('sheetId is required and must be a string');

--- a/index.js
+++ b/index.js
@@ -319,6 +319,19 @@ function OrcaScanNode(apiKey, options) {
             if (!rowIds || Object.prototype.toString.call(rowIds) !== '[object Array]') throw new Error('rowIds is required and must be an array of strings');
 
             return request.call(self, 'DELETE', '/sheets/' + encodeURIComponent(sheetId) + '/rows', null, rowIds);
+        },
+
+        /**
+         * get the total number of rows in a sheet
+         * @param {string} sheetId - target sheet id
+         * @returns {Promise<object>} promise resolving to result
+         *   {object} data - count result
+         *   {number} data.count - total number of rows
+         */
+        count: function (sheetId) {
+            if (!sheetId || typeof sheetId !== 'string') throw new Error('sheetId is required and must be a string');
+
+            return request.call(self, 'GET', '/sheets/' + encodeURIComponent(sheetId) + '/rows/count');
         }
     };
 

--- a/tests/interface-spec.js
+++ b/tests/interface-spec.js
@@ -54,6 +54,7 @@ describe('Interface', function() {
         expect(typeof client.rows.updateMany).toBe('function');
         expect(typeof client.rows.deleteOne).toBe('function');
         expect(typeof client.rows.deleteMany).toBe('function');
+        expect(typeof client.rows.count).toBe('function');
     });
 
     it('should expose fields methods', function() {
@@ -206,7 +207,7 @@ describe('Interface', function() {
     it('should expose the correct number of methods per namespace', function() {
         // Verify expected method counts for each namespace
         expect(Object.keys(client.sheets).length).toBe(5); // list, create, settings, clear, rename, delete
-        expect(Object.keys(client.rows).length).toBe(7); // list, get, add, updateOne, updateMany, deleteOne, deleteMany
+        expect(Object.keys(client.rows).length).toBe(8); // list, get, add, updateOne, updateMany, deleteOne, deleteMany, count
         expect(Object.keys(client.fields).length).toBe(5); // list, get, create, update, delete
         expect(Object.keys(client.history).length).toBe(2); // sheet, row
         expect(Object.keys(client.users).length).toBe(4); // list, add, update, remove

--- a/tests/interface-spec.js
+++ b/tests/interface-spec.js
@@ -206,7 +206,7 @@ describe('Interface', function() {
 
     it('should expose the correct number of methods per namespace', function() {
         // Verify expected method counts for each namespace
-        expect(Object.keys(client.sheets).length).toBe(5); // list, create, settings, clear, rename, delete
+        expect(Object.keys(client.sheets).length).toBe(5); // list, create, clear, rename, delete
         expect(Object.keys(client.rows).length).toBe(8); // list, get, add, updateOne, updateMany, deleteOne, deleteMany, count
         expect(Object.keys(client.fields).length).toBe(5); // list, get, create, update, delete
         expect(Object.keys(client.history).length).toBe(2); // sheet, row

--- a/tests/rows-spec.js
+++ b/tests/rows-spec.js
@@ -322,6 +322,37 @@ describe('Rows', function() {
         }).toThrowError('rowIds is required and must be an array of strings');
     });
 
+    it('should get row count', function() {
+        mockFetch.and.returnValue(Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: { get: function() { return null; } },
+            text: function() { return Promise.resolve('{"data": {"count": 42}}'); }
+        }));
+
+        return client.rows.count('test-sheet-id').then(function(result) {
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://api.orcascan.com/v1/sheets/test-sheet-id/rows/count',
+                jasmine.objectContaining({
+                    method: 'GET'
+                })
+            );
+            expect(result.count).toBe(42);
+        });
+    });
+
+    it('should throw error when counting rows without sheetId', function() {
+        expect(function() {
+            client.rows.count();
+        }).toThrowError('sheetId is required and must be a string');
+    });
+
+    it('should throw error when counting rows with non-string sheetId', function() {
+        expect(function() {
+            client.rows.count(123);
+        }).toThrowError('sheetId is required and must be a string');
+    });
+
     it('should handle rowId with special characters in URL encoding', function() {
         var sheetId = 'test-sheet-id';
         var rowId = 'test/row:id';


### PR DESCRIPTION
This pull request adds a new method to the `rows` namespace for counting the total number of rows in a sheet and includes corresponding tests and interface updates. The main focus is on improving the API's functionality by enabling users to retrieve row counts directly.

### New feature: Row count method

* Added a `count` method to the `rows` namespace in `index.js`, allowing users to get the total number of rows in a sheet by sheet ID, with input validation for the `sheetId` parameter.

### Test coverage and interface updates

* Added unit tests in `tests/rows-spec.js` to verify the correct behavior of the new `count` method, including successful retrieval, proper API call, and error handling for missing or invalid `sheetId`.
* Updated the interface test in `tests/interface-spec.js` to check that `rows.count` is exposed as a function.
* Adjusted the expected method count for `rows` in the interface test to reflect the addition of the new `count` method.