### PR TITLE
Add partial row updates & remove fields.get

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Required: your Orca Scan API key (https://orcascan.com/guides/barcode-scanning-rest-api-f09a21c3)
+ORCA_SCAN_API_KEY=your-api-key-here
+
+# Optional: override the API endpoint (defaults to https://api.orcascan.com/v1)
+# ORCA_SCAN_ENDPOINT=https://api.orcascan.com/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,204 +2,29 @@ name: Orca Scan Node SDK Tests
 
 on:
   pull_request:
-    branches: [master, dev]
-    types: [synchronize, review_requested, edited, reopened, opened, ready_for_review]
+    branches: [master]
   push:
     branches: [master]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-integration-tests
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  prepare-repos:
-    runs-on: self-hosted
+  test:
+    runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false || github.ref == 'refs/heads/master' }}
-    strategy:
-      matrix:
-        repos: [
-          "orca-scan/orca-scan-node"
-        ]
-    outputs:
-      folder_id: ${{ steps.folder_id.outputs.SAFE_ID }}
-      repo_name: ${{ steps.repo_name.outputs.SAFE_REPO }}
-      find_branch: ${{ steps.find_branch.outputs.branch }}
-  
-    steps:
-      - name: Extract branch name
-        shell: bash
-        id: extract_branch
-        run: |
-          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-    
-      - name: Sanitize ID
-        id: folder_id
-        run: |
-          ID="${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-desktop-master"
-          SAFE_ID=$(echo "$ID" | sed 's#[^a-zA-Z0-9._-]#_#g')
-          mkdir -p "/mnt/git-cache/$SAFE_ID"
-          echo "SAFE_ID=$SAFE_ID" >> $GITHUB_OUTPUT
-    
-      - name: Force Git to use SSH
-        run: git config --global url."git@github.com:".insteadOf "https://github.com/"
-    
-      - name: Sanitize repo
-        id: repo_name
-        run: |
-          REPO="${{ matrix.repos }}"
-          SAFE_REPO=$(basename "$REPO")
-          echo "SAFE_REPO=$SAFE_REPO" >> $GITHUB_OUTPUT
-
-      - name: Find matching branch
-        id: find_branch
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.BUILD_BOT_ACCESS }}
-        run: |
-          REPO="${{ matrix.repos }}"
-          CURRENT_BRANCH="${{ steps.extract_branch.outputs.branch }}"
-          BASE_BRANCH="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}"
-          BRANCHES_TO_CHECK=("$CURRENT_BRANCH" "master" "main" "dev")
-          if [ "$BASE_BRANCH" = "dev" ]; then
-            BRANCHES_TO_CHECK=("$CURRENT_BRANCH" "dev" "main" "master")
-          fi
-          MATCHED_BRANCH=""
-          for BRANCH in "${BRANCHES_TO_CHECK[@]}"; do
-            if gh api repos/$REPO/branches/$BRANCH --silent > /dev/null 2>&1; then
-              MATCHED_BRANCH="$BRANCH"
-              break
-            fi
-          done
-          if [ -z "$MATCHED_BRANCH" ]; then
-            MATCHED_BRANCH="master"
-          fi
-          SAFE_REPO=$(basename "$REPO" | sed 's/[-.]/_/g')
-          echo "branch=$MATCHED_BRANCH" >> $GITHUB_OUTPUT
-          echo "$MATCHED_BRANCH" > "/mnt/git-cache/${{steps.folder_id.outputs.SAFE_ID}}/${SAFE_REPO}_branch"
-
-    
-      - name: Check and Get Repo
-        id: repo_check
-        run: |
-          REPO_PATH="/mnt/git-cache/${{ steps.folder_id.outputs.SAFE_ID }}/${{ steps.repo_name.outputs.SAFE_REPO }}"
-          
-          if [ -d "$REPO_PATH/.git" ]; then
-            echo "Repository cache exists, copying back and updating..."
-            rsync -a "$REPO_PATH/" "./${{ steps.repo_name.outputs.SAFE_REPO }}/"
-            cd "${{ steps.repo_name.outputs.SAFE_REPO }}"
-            git fetch origin ${{ steps.find_branch.outputs.branch }}
-            git stash
-            git reset --hard origin/${{ steps.find_branch.outputs.branch }}
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Repository cache doesn't exist, will perform fresh checkout..."
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Fresh Checkout
-        if: steps.repo_check.outputs.exists == 'false'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.find_branch.outputs.branch }}
-          repository: ${{ matrix.repos }}
-          token: ${{ secrets.BUILD_BOT_ACCESS }}
-          path: ${{ steps.repo_name.outputs.SAFE_REPO }}
-        
-      - name: Get node version from package.json
-        id: get-node-version
-        run: |
-          version=$(jq -r '.engines.node // empty' ${{ steps.repo_name.outputs.SAFE_REPO }}/package.json | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "")
-          if [ -z "$version" ]; then
-            echo "NODE_VERSION=20" >> $GITHUB_OUTPUT
-          else
-            echo "NODE_VERSION=$version" >> $GITHUB_OUTPUT
-          fi
-              
-      - name: Use Node.js version
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-          token: ${{ secrets.BUILD_BOT_ACCESS }}
-      
-      - name: npm install
-        run: |
-          cd "${{ steps.repo_name.outputs.SAFE_REPO }}"
-          npm install --install-links=false
-          sleep 10
-
-      - name: Copy Repo to cache
-        run: |
-          set -e
-          sync
-          echo "Copying ${{ steps.repo_name.outputs.SAFE_REPO }} to cache..."
-          rsync -a --delete "${{ steps.repo_name.outputs.SAFE_REPO }}/" "/mnt/git-cache/${{ steps.folder_id.outputs.SAFE_ID }}/${{ steps.repo_name.outputs.SAFE_REPO }}/"
-          echo "Copy completed for ${{ steps.repo_name.outputs.SAFE_REPO }}"
-          sleep 10
-
-  run-tests:
-    needs: prepare-repos
-    runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
-      - name: Prepare apt
-        run: |
-          for i in {1..5}; do
-            sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock
-            
-            # Remove MongoDB key if it exists
-            sudo rm -f /usr/share/keyrings/mongodb-server-8.0.gpg
+      - uses: actions/checkout@v4
 
-            # Remove MongoDB repo list if it exists
-            sudo rm -f /etc/apt/sources.list.d/mongodb-org-8.0.list
-
-            sudo dpkg --configure -a
-            sudo apt-get clean
-            sudo apt-get update && break
-            sleep 5
-          done
-
-      - name: Install CI dependencies
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgtk2.0-0 \
-            libgtk-3-0 \
-            libgbm-dev \
-            libnotify-dev \
-            libnss3 \
-            libxss1 \
-            libasound2t64 \
-            alsa-utils \
-            libxtst6 \
-            xauth \
-            xvfb \
-            netcat-openbsd \
-            wget \
-            gnupg2
-          echo "Dependencies installed."
-
-      # Get Integrations
-      - name: Get orca-scan-node
-        run: |
-          echo "Copying orca-scan-node from cache..."
-          rsync -a "/mnt/git-cache/${{ needs.prepare-repos.outputs.folder_id }}/orca-scan-node/" "./orca-scan-node/"
-          echo "Copy completed for orca-scan-node"
-
-      - name: Use node version from package.json
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          token: ${{ secrets.BUILD_BOT_ACCESS }}
-          node-version-file: 'orca-scan-node/package.json'
+          node-version: 20
 
-      - name: Run SDK Tests
-        env:
-          NODE_ENV: test
-        working-directory: ./orca-scan-node
-        run: |
-          npm test
+      - name: Install dependencies
+        run: npm install
 
-      - name: Cleanup Directory
-        if: always()
-        run: rm -rf ./*
+      - name: Run tests
+        run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ orca.sheets.list().then(function(sheets) {
     // All errors have a 'message'.
     console.error('Error message:', error.message);
 
-    // If the error is from the API (like 401, 404, 422), these will also be set:
+    // If the error is from the API (like 400, 401, 404), these will also be set:
     if (error.status) {
         console.error('HTTP Status:', error.status); // e.g. 404
     }

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ async function main() {
   var sheet = await orca.sheets.create({ name: 'Inventory' });
 
   // 2. Add some fields
-  await orca.fields.create(sheet._id, { label: 'Product Name', format: 'string' });
-  await orca.fields.create(sheet._id, { label: 'Quantity', format: 'integer' });
+  await orca.fields.create(sheet._id, { label: 'Product Name', format: 'text' });
+  await orca.fields.create(sheet._id, { label: 'Quantity', format: 'number' });
 
   // 3. Add some rows
   await orca.rows.add(sheet._id, [
@@ -135,11 +135,6 @@ orca.fields.list('sheet-id').then(function(fields) {
     console.log('Sheet fields:', fields);
 });
 
-// get a single field
-orca.fields.get('sheet-id', 'field-key').then(function(field) {
-    console.log('Field:', field);
-});
-
 // create a new field
 orca.fields.create('sheet-id', {
     label: 'Product Code',
@@ -178,6 +173,8 @@ orca.fields.delete('sheet-id', 'field-key').then(function(result) {
     console.log('Field deleted');
 });
 ```
+
+> **Note:** `create`, `update`, and `delete` require `canAdmin: true` for the API key's user on the sheet. Attempting these without admin rights returns a `403 Forbidden`.
 
 #### Field options
 
@@ -247,7 +244,7 @@ orca.fields.delete('sheet-id', 'field-key').then(function(result) {
 ### Rows
 
 ```js
-let options = { withTitles: true };
+var options = { withTitles: true };
 
 // list all rows in a sheet
 orca.rows.list('sheet-id', options).then(function(rows) {
@@ -297,22 +294,19 @@ orca.rows.add('sheet-id', [
     console.log('Rows added:', rows);
 });
 
-// update one row
+// update one row (partial: true updates only provided fields, leaving others intact)
 orca.rows.updateOne('sheet-id', 'row-id', {
     quantity: 15
-}, options)
+}, { partial: true })
 .then(function(row) {
     console.log('Row updated:', row);
 });
-
-
-options = { partial: true, withTitles: true };
 
 // update many rows
 orca.rows.updateMany('sheet-id', [
     { _id: 'row1', quantity: 15 },
     { _id: 'row2', quantity: 20 }
-], options)
+], { partial: true })
 .then(function(rows) {
     console.log('Rows updated:', rows);
 });
@@ -336,7 +330,7 @@ orca.rows.count('sheet-id').then(function(result) {
 Each rows method accepts an optional `options` object. Supported options:
 
 - **withTitles**: Return field titles instead of field keys
-- **partial**: Update only the provided fields and leave all others unchanged _(only for `updateMany`)_
+- **partial**: Update only the provided fields and leave all others unchanged _(supported by `add`, `updateOne`, and `updateMany`)_
 
 ### History
 
@@ -472,7 +466,7 @@ orca.sheets.list().then(function(sheets) {
 | `http 403`           | Permission denied  | Verify your access rights             |
 | `http 429`           | Too many requests  | Requests are automatically retried    |
 | `http 404`           | Resource not found | Check sheet/row/field ID is correct   |
-| `http 422`           | Validation error   | Check field types and required fields |
+| `http 400`           | Bad request        | Check required fields and data types  |
 
 ## Automatic Retries
 
@@ -481,7 +475,7 @@ The client will automatically retry on:
 - Service unavailable (503) 
 - Server errors (5xx)
 
-Default: 3 retry attempts with exponential backoff
+Default: 3 retry attempts with linear backoff (500ms, 1000ms, 1500ms), or respects the `Retry-After` header if present
 
 ## Request Timeouts
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,8 +90,8 @@ export interface OrcaScan {
   rows: {
     list(sheetId: string, options?: { withTitles?: boolean; withTitle?: boolean }): Promise<Row[]>;
     get(sheetId: string, rowId: string, options?: { withTitles?: boolean; withTitle?: boolean }): Promise<Row>;
-    add(sheetId: string, data: Row | Row[], options?: { withTitles?: boolean; withTitle?: boolean }): Promise<Row | Row[]>;
-    updateOne(sheetId: string, rowId: string, data: Row, options?: { withTitles?: boolean; withTitle?: boolean }): Promise<Row>;
+    add(sheetId: string, data: Row | Row[], options?: { withTitles?: boolean; withTitle?: boolean; partial?: boolean }): Promise<Row | Row[]>;
+    updateOne(sheetId: string, rowId: string, data: Row, options?: { withTitles?: boolean; withTitle?: boolean; partial?: boolean }): Promise<Row>;
     updateMany(sheetId: string, rows: Row[], options?: { withTitles?: boolean; withTitle?: boolean; partial?: boolean }): Promise<Row[]>;
     deleteOne(sheetId: string, rowId: string): Promise<any>;
     deleteMany(sheetId: string, rowIds: string[]): Promise<any>;
@@ -99,7 +99,6 @@ export interface OrcaScan {
   };
   fields: {
     list(sheetId: string): Promise<Field[]>;
-    get(sheetId: string, fieldKey: string): Promise<Field>;
     create(sheetId: string, payload: Partial<Field> & { label: string; format: string }): Promise<Field>;
     update(sheetId: string, fieldKey: string, payload: Partial<Field>): Promise<Field>;
     delete(sheetId: string, fieldKey: string): Promise<any>;

--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ function OrcaScanNode(apiKey, options) {
                 query.withTitles = true;
             }
 
-            if (options && options.partial === true) {
+            if (options.partial === true) {
                 query.partial = true;
             }
 

--- a/index.js
+++ b/index.js
@@ -221,6 +221,7 @@ function OrcaScanNode(apiKey, options) {
          * @param {object} [options] - optional call options
          * @param {boolean} [options.withTitles=false] - if true, returns field titles rather than keys
          * @param {boolean} [options.withTitle=false] - legacy alias for withTitles
+         * @param {boolean} [options.partial=false] - if true, update only changed fields while all other fields remain intact
          * @returns {Promise<object>} promise resolving to result
          *   {object|array} data - created row or list of created rows with server assigned fields
          * 
@@ -240,6 +241,10 @@ function OrcaScanNode(apiKey, options) {
                 query.withTitles = true;
             }
 
+            if (options.partial === true) {
+                query.partial = true;
+            }
+
             return request.call(self, 'POST', '/sheets/' + encodeURIComponent(sheetId) + '/rows', query, data);
         },
 
@@ -251,6 +256,7 @@ function OrcaScanNode(apiKey, options) {
          * @param {object} [options] - optional call options
          * @param {boolean} [options.withTitles=false] - if true, returns field titles rather than keys
          * @param {boolean} [options.withTitle=false] - legacy alias for withTitles
+         * @param {boolean} [options.partial=false] - if true, update only changed fields while all other fields remain intact
          * @returns {Promise<object>} promise resolving to result
          *   {object} data - updated row with arbitrary properties
          */
@@ -264,6 +270,10 @@ function OrcaScanNode(apiKey, options) {
 
             if (useWithTitlesOption(options)) {
                 query.withTitles = true;
+            }
+
+            if (options.partial === true) {
+                query.partial = true;
             }
 
             return request.call(self, 'PUT', '/sheets/' + encodeURIComponent(sheetId) + '/rows/' + encodeURIComponent(rowId), query, data);
@@ -383,20 +393,6 @@ function OrcaScanNode(apiKey, options) {
             if (!sheetId || typeof sheetId !== 'string') throw new Error('sheetId is required and must be a string');
 
             return request.call(self, 'GET', '/sheets/' + encodeURIComponent(sheetId) + '/fields');
-        },
-
-        /**
-         * Get a single field by key
-         * @param {string} sheetId - target sheet id
-         * @param {string} fieldKey - field key
-         * @returns {Promise<object>} promise resolving to result
-         *   {object} data - field object with all properties
-         */
-        get: function (sheetId, fieldKey) {
-            if (!sheetId || typeof sheetId !== 'string') throw new Error('sheetId is required and must be a string');
-            if (!fieldKey || typeof fieldKey !== 'string') throw new Error('fieldKey is required and must be a string');
-
-            return request.call(self, 'GET', '/sheets/' + encodeURIComponent(sheetId) + '/fields/' + encodeURIComponent(fieldKey));
         },
 
         /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-scan/orca-scan-node",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-scan/orca-scan-node",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "engines": {
     "node": ">=14.16.0"
   },

--- a/package.json
+++ b/package.json
@@ -6,11 +6,18 @@
   },
   "description": "The official node client for the Orca Scan API",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "LICENSE",
+    "README.md"
+  ],
   "directories": {
     "test": "tests"
   },
   "scripts": {
-    "test": "NODE_ENV=test node_modules/.bin/jasmine --config=tests/jasmine/config.json"
+    "test": "NODE_ENV=test node_modules/.bin/jasmine --config=tests/jasmine/config.json",
+    "test-e2e": "node_modules/.bin/jasmine --config=tests/e2e/jasmine-e2e.config.json"
   },
   "repository": {
     "type": "git",

--- a/tests/e2e/01-sheets-e2e-spec.js
+++ b/tests/e2e/01-sheets-e2e-spec.js
@@ -1,0 +1,32 @@
+var setup = require('./setup');
+
+describe('e2e: sheets', function () {
+
+    var client = setup.getClient();
+    var sheetName = 'e2e-test-' + Date.now();
+
+    it('should create a new sheet', async function () {
+        var sheet = await client.sheets.create({ name: sheetName });
+        expect(sheet).toBeDefined();
+        expect(sheet._id).toBeDefined();
+        expect(sheet.name).toBe(sheetName);
+
+        // store for other specs
+        setup.setSheetId(sheet._id);
+    });
+
+    it('should list sheets and include the new one', async function () {
+        var sheets = await client.sheets.list();
+        expect(Array.isArray(sheets)).toBe(true);
+
+        var found = sheets.find(function (s) { return s._id === setup.getSheetId(); });
+        expect(found).toBeDefined();
+    });
+
+    it('should rename the sheet without error', async function () {
+        var newName = sheetName + '-renamed';
+        await client.sheets.rename(setup.getSheetId(), { name: newName });
+
+        // if rename returned without throwing, the API accepted it
+    });
+});

--- a/tests/e2e/02-settings-e2e-spec.js
+++ b/tests/e2e/02-settings-e2e-spec.js
@@ -1,0 +1,22 @@
+var setup = require('./setup');
+
+describe('e2e: settings', function () {
+
+    var client = setup.getClient();
+
+    it('should get sheet settings', async function () {
+        var settings = await client.settings.get(setup.getSheetId());
+        expect(settings).toBeDefined();
+        expect(typeof settings).toBe('object');
+    });
+
+    it('should update and read back a setting', async function () {
+        await client.settings.update(setup.getSheetId(), { allowPublicExport: true });
+
+        var settings = await client.settings.get(setup.getSheetId());
+        expect(settings.allowPublicExport).toBe(true);
+
+        // reset it
+        await client.settings.update(setup.getSheetId(), { allowPublicExport: false });
+    });
+});

--- a/tests/e2e/03-fields-e2e-spec.js
+++ b/tests/e2e/03-fields-e2e-spec.js
@@ -1,0 +1,45 @@
+var setup = require('./setup');
+
+describe('e2e: fields', function () {
+
+    var client = setup.getClient();
+    var fieldKey = null;
+
+    it('should create a field', async function () {
+        var field = await client.fields.create(setup.getSheetId(), {
+            label: 'E2E Notes',
+            format: 'text'
+        });
+        expect(field).toBeDefined();
+        expect(field.key).toBeDefined();
+        expect(field.label).toBe('E2E Notes');
+
+        fieldKey = field.key;
+    });
+
+    it('should list fields and include the new one', async function () {
+        var fields = await client.fields.list(setup.getSheetId());
+        expect(Array.isArray(fields)).toBe(true);
+
+        var found = fields.find(function (f) { return f.key === fieldKey; });
+        expect(found).toBeDefined();
+    });
+
+    it('should update the field label', async function () {
+        await client.fields.update(setup.getSheetId(), fieldKey, {
+            label: 'E2E Notes Updated'
+        });
+
+        var fields = await client.fields.list(setup.getSheetId());
+        var found = fields.find(function (f) { return f.key === fieldKey; });
+        expect(found.label).toBe('E2E Notes Updated');
+    });
+
+    it('should delete the field', async function () {
+        await client.fields.delete(setup.getSheetId(), fieldKey);
+
+        var fields = await client.fields.list(setup.getSheetId());
+        var found = fields.find(function (f) { return f.key === fieldKey; });
+        expect(found).toBeUndefined();
+    });
+});

--- a/tests/e2e/04-rows-e2e-spec.js
+++ b/tests/e2e/04-rows-e2e-spec.js
@@ -1,0 +1,71 @@
+var setup = require('./setup');
+
+describe('e2e: rows', function () {
+
+    var client = setup.getClient();
+    var rowId = null;
+    var rowId2 = null;
+
+    it('should add a row', async function () {
+        var row = await client.rows.add(setup.getSheetId(), { barcode: 'E2E-001' });
+        expect(row).toBeDefined();
+        expect(row._id).toBeDefined();
+
+        rowId = row._id;
+    });
+
+    it('should get a row by id', async function () {
+        var row = await client.rows.get(setup.getSheetId(), rowId);
+        expect(row).toBeDefined();
+        expect(row._id).toBe(rowId);
+    });
+
+    it('should list rows', async function () {
+        var rows = await client.rows.list(setup.getSheetId());
+        expect(Array.isArray(rows)).toBe(true);
+        expect(rows.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should update a single row', async function () {
+        await client.rows.updateOne(setup.getSheetId(), rowId, { barcode: 'E2E-002' });
+
+        var row = await client.rows.get(setup.getSheetId(), rowId);
+        expect(row.barcode).toBe('E2E-002');
+    });
+
+    it('should count rows', async function () {
+        var result = await client.rows.count(setup.getSheetId());
+        expect(result).toBeDefined();
+        expect(result.count).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should add a second row and update many', async function () {
+        var row2 = await client.rows.add(setup.getSheetId(), { barcode: 'E2E-003' });
+        rowId2 = row2._id;
+
+        await client.rows.updateMany(setup.getSheetId(), [
+            { _id: rowId, barcode: 'BATCH-1' },
+            { _id: rowId2, barcode: 'BATCH-2' }
+        ]);
+
+        var rows = await client.rows.list(setup.getSheetId());
+        var r1 = rows.find(function (r) { return r._id === rowId; });
+        var r2 = rows.find(function (r) { return r._id === rowId2; });
+        expect(r1.barcode).toBe('BATCH-1');
+        expect(r2.barcode).toBe('BATCH-2');
+    });
+
+    it('should delete a single row', async function () {
+        await client.rows.deleteOne(setup.getSheetId(), rowId);
+
+        var result = await client.rows.count(setup.getSheetId());
+        expect(result.count).toBe(1);
+    });
+
+    it('should delete many rows', async function () {
+        await client.rows.deleteMany(setup.getSheetId(), [rowId2]);
+
+        var result = await client.rows.count(setup.getSheetId());
+        expect(result.count).toBe(0);
+    });
+});

--- a/tests/e2e/05-history-e2e-spec.js
+++ b/tests/e2e/05-history-e2e-spec.js
@@ -1,0 +1,34 @@
+var setup = require('./setup');
+
+describe('e2e: history', function () {
+
+    var client = setup.getClient();
+    var rowId = null;
+
+    // create and update a row so history has entries
+    beforeAll(async function () {
+        var row = await client.rows.add(setup.getSheetId(), { barcode: 'HISTORY-001' });
+        rowId = row._id;
+        await client.rows.updateOne(setup.getSheetId(), rowId, { barcode: 'HISTORY-002' });
+    });
+
+    // clean up after
+    afterAll(async function () {
+        try {
+            await client.rows.deleteOne(setup.getSheetId(), rowId);
+        }
+        catch (err) { /* already deleted */ }
+    });
+
+    it('should get sheet history', async function () {
+        var history = await client.history.sheet(setup.getSheetId());
+        expect(Array.isArray(history)).toBe(true);
+        expect(history.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should get row history', async function () {
+        var history = await client.history.row(setup.getSheetId(), rowId);
+        expect(Array.isArray(history)).toBe(true);
+        expect(history.length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/tests/e2e/06-hooks-e2e-spec.js
+++ b/tests/e2e/06-hooks-e2e-spec.js
@@ -1,0 +1,60 @@
+var setup = require('./setup');
+
+describe('e2e: hooks', function () {
+
+    var client = setup.getClient();
+    var hookId = null;
+    var eventName = null;
+
+    it('should list available hook events', async function () {
+        var events = await client.hooks.events(setup.getSheetId());
+        expect(Array.isArray(events)).toBe(true);
+        expect(events.length).toBeGreaterThan(0);
+
+        // save for the create test
+        eventName = events[0];
+    });
+
+    it('should create a hook', async function () {
+        var hook = await client.hooks.create(setup.getSheetId(), {
+            eventName: eventName,
+            targetUrl: 'https://httpbin.org/post'
+        });
+        expect(hook).toBeDefined();
+        expect(hook._id).toBeDefined();
+
+        hookId = hook._id;
+    });
+
+    it('should list hooks and include the new one', async function () {
+        var hooks = await client.hooks.list(setup.getSheetId());
+        expect(Array.isArray(hooks)).toBe(true);
+
+        var found = hooks.find(function (h) { return h._id === hookId; });
+        expect(found).toBeDefined();
+    });
+
+    it('should get a hook by id', async function () {
+        var hook = await client.hooks.get(setup.getSheetId(), hookId);
+        expect(hook).toBeDefined();
+        expect(hook.targetUrl).toBe('https://httpbin.org/post');
+    });
+
+    it('should update a hook', async function () {
+        await client.hooks.update(setup.getSheetId(), hookId, {
+            eventName: eventName,
+            targetUrl: 'https://httpbin.org/put'
+        });
+
+        var hook = await client.hooks.get(setup.getSheetId(), hookId);
+        expect(hook.targetUrl).toBe('https://httpbin.org/put');
+    });
+
+    it('should delete a hook', async function () {
+        await client.hooks.delete(setup.getSheetId(), hookId);
+
+        var hooks = await client.hooks.list(setup.getSheetId());
+        var found = hooks.find(function (h) { return h._id === hookId; });
+        expect(found).toBeUndefined();
+    });
+});

--- a/tests/e2e/07-users-e2e-spec.js
+++ b/tests/e2e/07-users-e2e-spec.js
@@ -1,0 +1,11 @@
+var setup = require('./setup');
+
+describe('e2e: users', function () {
+
+    var client = setup.getClient();
+
+    it('should list users on the sheet', async function () {
+        var users = await client.users.list(setup.getSheetId());
+        expect(Array.isArray(users)).toBe(true);
+    });
+});

--- a/tests/e2e/99-teardown-e2e-spec.js
+++ b/tests/e2e/99-teardown-e2e-spec.js
@@ -1,0 +1,20 @@
+var setup = require('./setup');
+
+describe('e2e: teardown', function () {
+
+    var client = setup.getClient();
+
+    it('should delete the test sheet', async function () {
+        var sheetId = setup.getSheetId();
+        if (!sheetId) {
+            return; // nothing to clean up
+        }
+
+        await client.sheets.delete(sheetId);
+
+        // confirm it's gone
+        var sheets = await client.sheets.list();
+        var found = sheets.find(function (s) { return s._id === sheetId; });
+        expect(found).toBeUndefined();
+    });
+});

--- a/tests/e2e/jasmine-e2e.config.json
+++ b/tests/e2e/jasmine-e2e.config.json
@@ -1,12 +1,11 @@
 {
-  "spec_dir": "tests",
+  "spec_dir": "tests/e2e",
   "spec_files": [
-    "**/*[sS]pec.?(m)js",
-    "!e2e/**"
+    "**/*-e2e-spec.js"
   ],
   "helpers": [
-    "jasmine/reporter.js",
-    "jasmine/timeout.js"
+    "../jasmine/reporter.js",
+    "../jasmine/timeout.js"
   ],
   "env": {
     "stopSpecOnExpectationFailure": false,

--- a/tests/e2e/setup.js
+++ b/tests/e2e/setup.js
@@ -1,0 +1,47 @@
+var fs = require('fs');
+var path = require('path');
+var OrcaScanNode = require('../../index');
+
+// load .env file if it exists (no extra dependencies needed)
+var envPath = path.resolve(__dirname, '../../.env');
+if (fs.existsSync(envPath)) {
+    fs.readFileSync(envPath, 'utf8').split('\n').forEach(function (line) {
+        line = line.trim();
+        if (!line || line.startsWith('#')) return;
+        var parts = line.split('=');
+        var key = parts[0].trim();
+        var val = parts.slice(1).join('=').trim();
+        if (!process.env[key]) process.env[key] = val;
+    });
+}
+
+var apiKey = process.env.ORCA_SCAN_API_KEY;
+var endpoint = process.env.ORCA_SCAN_ENDPOINT;
+
+// bail early with a clear message if no API key
+if (!apiKey) {
+    console.error('\n  E2E tests require ORCA_SCAN_API_KEY env var. See .env.example\n');
+    process.exit(1);
+}
+
+// create a single client shared by all specs
+var options = {};
+if (endpoint) {
+    options.endpoint = endpoint;
+}
+var client = new OrcaScanNode(apiKey, options);
+
+// shared state between specs (set by sheets spec, read by everything else)
+var sheetId = null;
+
+module.exports = {
+    getClient: function () {
+        return client;
+    },
+    getSheetId: function () {
+        return sheetId;
+    },
+    setSheetId: function (id) {
+        sheetId = id;
+    }
+};

--- a/tests/fields-spec.js
+++ b/tests/fields-spec.js
@@ -64,48 +64,6 @@ describe('Fields', function() {
         }).toThrowError('sheetId is required and must be a string');
     });
 
-    it('should fetch single field by key', function() {
-        var sheetId = 'test-sheet-id';
-        var fieldKey = 'test-field';
-        
-        return client.fields.get(sheetId, fieldKey).then(function(result) {
-            expect(mockFetch).toHaveBeenCalledWith(
-                'https://api.orcascan.com/v1/sheets/test-sheet-id/fields/test-field',
-                jasmine.objectContaining({
-                    method: 'GET',
-                    headers: jasmine.objectContaining({
-                        'Authorization': 'Bearer test-api-key'
-                    })
-                })
-            );
-            expect(result).toBeDefined();
-        });
-    });
-
-    it('should reject when getting field without sheetId', function() {
-        expect(function() {
-            client.fields.get();
-        }).toThrowError('sheetId is required and must be a string');
-    });
-
-    it('should reject when getting field without fieldKey', function() {
-        expect(function() {
-            client.fields.get('test-sheet-id');
-        }).toThrowError('fieldKey is required and must be a string');
-    });
-
-    it('should reject when getting field with non-string sheetId', function() {
-        expect(function() {
-            client.fields.get(123, 'test-field');
-        }).toThrowError('sheetId is required and must be a string');
-    });
-
-    it('should throw error when getting field with non-string fieldKey', function() {
-        expect(function() {
-            client.fields.get('test-sheet-id', 123);
-        }).toThrowError('fieldKey is required and must be a string');
-    });
-
     it('should create a field with required properties', function() {
         var sheetId = 'test-sheet-id';
         var payload = {
@@ -316,21 +274,6 @@ describe('Fields', function() {
         expect(function() {
             client.fields.delete('test-sheet-id', 123);
         }).toThrowError('fieldKey is required and must be a string');
-    });
-
-    it('should handle sheetId with special characters in URL encoding', function() {
-        var sheetId = 'test/sheet:id';
-        var fieldKey = 'test/field:key';
-        
-        return client.fields.get(sheetId, fieldKey).then(function(result) {
-            expect(mockFetch).toHaveBeenCalledWith(
-                'https://api.orcascan.com/v1/sheets/test%2Fsheet%3Aid/fields/test%2Ffield%3Akey',
-                jasmine.objectContaining({
-                    method: 'GET'
-                })
-            );
-            expect(result).toBeDefined();
-        });
     });
 
     it('should handle fieldKey with special characters in URL encoding', function() {

--- a/tests/interface-spec.js
+++ b/tests/interface-spec.js
@@ -59,7 +59,6 @@ describe('Interface', function() {
 
     it('should expose fields methods', function() {
         expect(typeof client.fields.list).toBe('function');
-        expect(typeof client.fields.get).toBe('function');
         expect(typeof client.fields.create).toBe('function');
         expect(typeof client.fields.update).toBe('function');
         expect(typeof client.fields.delete).toBe('function');
@@ -154,7 +153,6 @@ describe('Interface', function() {
         expect(typeof client.hooks.list).toBe('function');
         
         expect(typeof client.rows.get).toBe('function');
-        expect(typeof client.fields.get).toBe('function');
         expect(typeof client.hooks.get).toBe('function');
         
         expect(typeof client.sheets.create).toBe('function');
@@ -208,7 +206,7 @@ describe('Interface', function() {
         // Verify expected method counts for each namespace
         expect(Object.keys(client.sheets).length).toBe(5); // list, create, clear, rename, delete
         expect(Object.keys(client.rows).length).toBe(8); // list, get, add, updateOne, updateMany, deleteOne, deleteMany, count
-        expect(Object.keys(client.fields).length).toBe(5); // list, get, create, update, delete
+        expect(Object.keys(client.fields).length).toBe(4); // list, create, update, delete
         expect(Object.keys(client.history).length).toBe(2); // sheet, row
         expect(Object.keys(client.users).length).toBe(4); // list, add, update, remove
         expect(Object.keys(client.hooks).length).toBe(6); // events, list, get, create, update, delete

--- a/tests/rows-spec.js
+++ b/tests/rows-spec.js
@@ -432,4 +432,50 @@ describe('Rows', function() {
             );
         });
     });
+
+    it('should pass partial=true query param when adding rows with partial option', function() {
+        var sheetId = 'test-sheet-id';
+        var data = { name: 'Item' };
+        return client.rows.add(sheetId, data, { partial: true }).then(function() {
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://api.orcascan.com/v1/sheets/test-sheet-id/rows?partial=true',
+                jasmine.objectContaining({ method: 'POST' })
+            );
+        });
+    });
+
+    it('should not pass partial query param when adding rows without partial option', function() {
+        var sheetId = 'test-sheet-id';
+        var data = { name: 'Item' };
+        return client.rows.add(sheetId, data).then(function() {
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://api.orcascan.com/v1/sheets/test-sheet-id/rows',
+                jasmine.objectContaining({ method: 'POST' })
+            );
+        });
+    });
+
+    it('should pass partial=true query param when updating one row with partial option', function() {
+        var sheetId = 'test-sheet-id';
+        var rowId = 'test-row-id';
+        var data = { quantity: 5 };
+        return client.rows.updateOne(sheetId, rowId, data, { partial: true }).then(function() {
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://api.orcascan.com/v1/sheets/test-sheet-id/rows/test-row-id?partial=true',
+                jasmine.objectContaining({ method: 'PUT' })
+            );
+        });
+    });
+
+    it('should not pass partial query param when updating one row without partial option', function() {
+        var sheetId = 'test-sheet-id';
+        var rowId = 'test-row-id';
+        var data = { quantity: 5 };
+        return client.rows.updateOne(sheetId, rowId, data).then(function() {
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://api.orcascan.com/v1/sheets/test-sheet-id/rows/test-row-id',
+                jasmine.objectContaining({ method: 'PUT' })
+            );
+        });
+    });
 });


### PR DESCRIPTION
* Add support for a partial option on `rows.add` and `rows.updateOne` (propagates ?partial=true to requests) and add the partial flag to TypeScript definitions.
* Remove the deprecated `fields.get` API (implementation, type, and tests).
* Update README examples and docs (field format labels, admin note, options docs, retry/backoff details
* Adjust tests to cover the new partial behavior and the removed `fields.get` surface