### PR TITLE
Adds `fields.upsert` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,18 @@ orca.fields.update('sheet-id', 'field-key', {
 orca.fields.delete('sheet-id', 'field-key').then(function(result) {
     console.log('Field deleted');
 });
+
+// upsert multiple fields - creates a field if it does not exist, otherwise updates it
+orca.fields.upsert('sheet-id', [
+    { label: 'Quantity', format: 'number' },
+    { label: 'Notes', format: 'text', required: true }
+])
+.then(function(fields) {
+    console.log('Fields upserted:', fields);
+});
 ```
 
-> **Note:** `create`, `update`, and `delete` require `canAdmin: true` for the API key's user on the sheet. Attempting these without admin rights returns a `403 Forbidden`.
+> **Note:** `create`, `update`, `delete`, and `upsert` require `canAdmin: true` for the API key's user on the sheet. Attempting these without admin rights returns a `403 Forbidden`.
 
 #### Field options
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,7 @@ export interface OrcaScan {
     create(sheetId: string, payload: Partial<Field> & { label: string; format: string }): Promise<Field>;
     update(sheetId: string, fieldKey: string, payload: Partial<Field>): Promise<Field>;
     delete(sheetId: string, fieldKey: string): Promise<any>;
+    upsert(sheetId: string, fields: Array<Partial<Field> & { label: string; format: string }>): Promise<Field[]>;
   };
   history: {
     sheet(sheetId: string): Promise<any[]>;

--- a/index.js
+++ b/index.js
@@ -476,8 +476,7 @@ function OrcaScanNode(apiKey, options) {
          * @param {boolean} [fields[].useInMobileSearch=true] - if true, field is searchable in mobile list
          * @param {boolean} [fields[].useValueInList=true] - if true, field is visible in mobile list
          * @param {number} [fields[].index] - if provided, sets the display order of the field
-         * @returns {Promise<object>} promise resolving to result
-         *   {array} data - upserted fields with all properties
+         * @returns {Promise<array>} promise resolving to an array of upserted fields with all properties
          */
         upsert: function (sheetId, fields) {
             if (!sheetId || typeof sheetId !== 'string') throw new Error('sheetId is required and must be a string');

--- a/index.js
+++ b/index.js
@@ -458,6 +458,35 @@ function OrcaScanNode(apiKey, options) {
         },
 
         /**
+         * Upsert multiple fields in a sheet - creates a field if it does not exist, otherwise updates it
+         * @param {string} sheetId - target sheet id
+         * @param {array} fields - array of field definitions
+         * @param {string} fields[].label - field label (display name)
+         * @param {string} fields[].format - field format (text, barcode, number, date, date time, time, email, gps location, true/false, currency, drop-down list, formula, signature, unique id, photo, attachment, url, created by, created date, last modified by, last modified date)
+         * @param {boolean} [fields[].required=false] - is field required
+         * @param {string} [fields[].placeholder] - guidance text when field is empty
+         * @param {boolean} [fields[].autofocus=false] - if true, UI auto selects this field first
+         * @param {boolean} [fields[].autoselect=false] - if true, existing text is highlighted on focus
+         * @param {boolean} [fields[].emptyOnEdit=false] - if true, value is cleared when record edited
+         * @param {boolean} [fields[].emptyOnScan=false] - if true, existing value is removed on scan
+         * @param {boolean} [fields[].hiddenMobile=false] - if true, field is hidden on mobile
+         * @param {boolean} [fields[].hiddenWeb=false] - if true, field is hidden on web
+         * @param {boolean} [fields[].readonlyWeb=false] - if true, field is read-only on web
+         * @param {boolean} [fields[].readonlyMobile=false] - if true, field is read-only on mobile
+         * @param {boolean} [fields[].useInMobileSearch=true] - if true, field is searchable in mobile list
+         * @param {boolean} [fields[].useValueInList=true] - if true, field is visible in mobile list
+         * @param {number} [fields[].index] - if provided, sets the display order of the field
+         * @returns {Promise<object>} promise resolving to result
+         *   {array} data - upserted fields with all properties
+         */
+        upsert: function (sheetId, fields) {
+            if (!sheetId || typeof sheetId !== 'string') throw new Error('sheetId is required and must be a string');
+            if (!fields || Object.prototype.toString.call(fields) !== '[object Array]') throw new Error('fields is required and must be an array of objects');
+
+            return request.call(self, 'PUT', '/sheets/' + encodeURIComponent(sheetId) + '/fields', null, fields);
+        },
+
+        /**
          * Delete a field from a sheet
          * @param {string} sheetId - target sheet id
          * @param {string} fieldKey - field key to delete

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-scan/orca-scan-node",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-scan/orca-scan-node",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "engines": {
     "node": ">=14.16.0"
   },

--- a/tests/e2e/03-fields-e2e-spec.js
+++ b/tests/e2e/03-fields-e2e-spec.js
@@ -58,6 +58,27 @@ describe('e2e: fields', function () {
         expect(updated.index).toBe(1);
     });
 
+    it('should upsert multiple fields', async function () {
+        var upserted = await client.fields.upsert(setup.getSheetId(), [
+            { label: 'E2E Upsert Field A', format: 'text' },
+            { label: 'E2E Upsert Field B', format: 'number', required: true }
+        ]);
+
+        expect(Array.isArray(upserted)).toBe(true);
+        expect(upserted.length).toBe(2);
+
+        var allFields = await client.fields.list(setup.getSheetId());
+        var foundA = allFields.find(function (f) { return f.label === 'E2E Upsert Field A'; });
+        var foundB = allFields.find(function (f) { return f.label === 'E2E Upsert Field B'; });
+        expect(foundA).toBeDefined();
+        expect(foundB).toBeDefined();
+        expect(foundB.required).toBe(true);
+
+        // clean up
+        await client.fields.delete(setup.getSheetId(), foundA.key);
+        await client.fields.delete(setup.getSheetId(), foundB.key);
+    });
+
     it('should delete the field', async function () {
         await client.fields.delete(setup.getSheetId(), fieldKey);
 

--- a/tests/fields-spec.js
+++ b/tests/fields-spec.js
@@ -320,4 +320,55 @@ describe('Fields', function() {
             expect(result).toBeDefined();
         });
     });
+
+    it('should upsert multiple fields', function() {
+        var sheetId = 'test-sheet-id';
+        var fields = [
+            { label: 'Quantity', format: 'number' },
+            { label: 'Notes', format: 'text', required: true }
+        ];
+
+        return client.fields.upsert(sheetId, fields).then(function(result) {
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://api.orcascan.com/v1/sheets/test-sheet-id/fields',
+                jasmine.objectContaining({
+                    method: 'PUT',
+                    headers: jasmine.objectContaining({
+                        'Authorization': 'Bearer test-api-key',
+                        'Content-Type': 'application/json'
+                    }),
+                    body: JSON.stringify(fields)
+                })
+            );
+            expect(result).toBeDefined();
+        });
+    });
+
+    it('should throw error when upserting fields without sheetId', function() {
+        expect(function() {
+            client.fields.upsert();
+        }).toThrowError('sheetId is required and must be a string');
+    });
+
+    it('should throw error when upserting fields with non-string sheetId', function() {
+        expect(function() {
+            client.fields.upsert(123, []);
+        }).toThrowError('sheetId is required and must be a string');
+    });
+
+    it('should throw error when upserting fields without fields array', function() {
+        expect(function() {
+            client.fields.upsert('test-sheet-id');
+        }).toThrowError('fields is required and must be an array of objects');
+    });
+
+    it('should throw error when upserting fields with non-array fields', function() {
+        expect(function() {
+            client.fields.upsert('test-sheet-id', { label: 'Test', format: 'text' });
+        }).toThrowError('fields is required and must be an array of objects');
+
+        expect(function() {
+            client.fields.upsert('test-sheet-id', 'invalid');
+        }).toThrowError('fields is required and must be an array of objects');
+    });
 });

--- a/tests/interface-spec.js
+++ b/tests/interface-spec.js
@@ -206,7 +206,7 @@ describe('Interface', function() {
         // Verify expected method counts for each namespace
         expect(Object.keys(client.sheets).length).toBe(5); // list, create, clear, rename, delete
         expect(Object.keys(client.rows).length).toBe(8); // list, get, add, updateOne, updateMany, deleteOne, deleteMany, count
-        expect(Object.keys(client.fields).length).toBe(4); // list, create, update, delete
+        expect(Object.keys(client.fields).length).toBe(5); // list, create, update, delete, upsert
         expect(Object.keys(client.history).length).toBe(2); // sheet, row
         expect(Object.keys(client.users).length).toBe(4); // list, add, update, remove
         expect(Object.keys(client.hooks).length).toBe(6); // events, list, get, create, update, delete


### PR DESCRIPTION
This PR adds `fields.upsert` method to match the [REST API PR](https://github.com/orca-scan/orca-public-api/pull/51), which allows fields to be added/updated in bulk.